### PR TITLE
fix: Graceful Union registration failure, new filters

### DIFF
--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -63,10 +63,17 @@ class PostObject {
 		if ( 'interface' === $post_type_object->graphql_kind ) {
 			register_graphql_interface_type( $single_name, $config );
 		} elseif ( 'union' === $post_type_object->graphql_kind ) {
-			// Set the possible types for the union.
-			$config['typeNames'] = $post_type_object->graphql_union_types;
 
-			register_graphql_union_type( $single_name, $config );
+			if ( ! empty( $post_type_object->graphql_union_types ) && is_array( $post_type_object->graphql_union_types ) ) {
+
+				// Set the possible types for the union.
+				$config['typeNames'] = $post_type_object->graphql_union_types;
+
+				register_graphql_union_type( $single_name, $config );
+
+			} else {
+				graphql_debug( 'Registering a post type with "graphql_kind" => "union" requires "graphql_union_types" to also be set', [ 'registered_post_type_object' => $post_type_object ] );
+			}
 		}
 	}
 
@@ -296,11 +303,10 @@ class PostObject {
 	/**
 	 * Registers common post type fields on schema type corresponding to provided post type object.
 	 *
-	 * @todo make protected after \Type\ObjectType\PostObject::get_fields() is removed.
-	 *
 	 * @param WP_Post_Type $post_type_object Post type.
 	 *
 	 * @return array
+	 * @todo make protected after \Type\ObjectType\PostObject::get_fields() is removed.
 	 */
 	public static function get_fields( WP_Post_Type $post_type_object ) {
 		$single_name = $post_type_object->graphql_single_name;
@@ -349,14 +355,14 @@ class PostObject {
 		}
 
 		if ( ! $post_type_object->hierarchical &&
-				! in_array(
-					$post_type_object->name,
-					[
-						'attachment',
-						'revision',
-					],
-					true
-				) ) {
+			! in_array(
+				$post_type_object->name,
+				[
+					'attachment',
+					'revision',
+				],
+				true
+			) ) {
 			$fields['ancestors']['deprecationReason'] = __( 'This content type is not hierarchical and typcially will not have ancestors', 'wp-graphql' );
 			$fields['parent']['deprecationReason']    = __( 'This content type is not hierarchical and typcially will not have a parent', 'wp-graphql' );
 		}
@@ -438,7 +444,11 @@ class PostObject {
 						$image = wp_get_attachment_image_src( $source->ID, $size );
 						if ( $image ) {
 							list( $src, $width, $height ) = $image;
-							$sizes                        = wp_calculate_image_sizes( [ absint( $width ), absint( $height ) ], $src, null, $source->ID );
+							$sizes                        = wp_calculate_image_sizes( [
+								absint( $width ),
+								absint( $height ),
+							], $src, null, $source->ID );
+
 							return ! empty( $sizes ) ? $sizes : null;
 						}
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -94,8 +94,8 @@ final class WPGraphQL {
 	 * The whole idea of the singleton design pattern is that there is a single object
 	 * therefore, we don't want the object to be cloned.
 	 *
-	 * @since  0.0.1
 	 * @return void
+	 * @since  0.0.1
 	 */
 	public function __clone() {
 
@@ -107,8 +107,8 @@ final class WPGraphQL {
 	/**
 	 * Disable unserializing of the class.
 	 *
-	 * @since  0.0.1
 	 * @return void
+	 * @since  0.0.1
 	 */
 	public function __wakeup() {
 
@@ -120,8 +120,8 @@ final class WPGraphQL {
 	/**
 	 * Setup plugin constants.
 	 *
-	 * @since  0.0.1
 	 * @return void
+	 * @since  0.0.1
 	 */
 	private function setup_constants() {
 
@@ -159,8 +159,8 @@ final class WPGraphQL {
 	 * Include required files.
 	 * Uses composer's autoload
 	 *
-	 * @since  0.0.1
 	 * @return bool
+	 * @since  0.0.1
 	 */
 	private function includes() {
 
@@ -229,7 +229,8 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Sets up actions to run at certain spots throughout WordPress and the WPGraphQL execution cycle
+	 * Sets up actions to run at certain spots throughout WordPress and the WPGraphQL execution
+	 * cycle
 	 *
 	 * @return void
 	 */
@@ -307,9 +308,8 @@ final class WPGraphQL {
 	 * If the server is running a lower version than required, throw an exception and prevent
 	 * further execution.
 	 *
-	 * @throws Exception
-	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function min_php_version_check() {
 
@@ -381,7 +381,10 @@ final class WPGraphQL {
 		);
 
 		// Filter how metadata is retrieved during GraphQL requests
-		add_filter( 'get_post_metadata', [ Preview::class, 'filter_post_meta_for_previews' ], 10, 4 );
+		add_filter( 'get_post_metadata', [
+			Preview::class,
+			'filter_post_meta_for_previews',
+		], 10, 4 );
 
 		/**
 		 * Adds back compat support for the `graphql_object_type_interfaces` filter which was renamed
@@ -395,12 +398,13 @@ final class WPGraphQL {
 				/**
 				 * Filters the interfaces applied to an object type
 				 *
-				 * @param array        $interfaces     List of interfaces applied to the Object Type
-				 * @param array        $config         The config for the Object Type
-				 * @param mixed|WPInterfaceType|WPObjectType $type The Type instance
+				 * @param array                              $interfaces List of interfaces applied to the Object Type
+				 * @param array                              $config     The config for the Object Type
+				 * @param mixed|WPInterfaceType|WPObjectType $type       The Type instance
 				 */
 				return apply_filters( 'graphql_object_type_interfaces', $interfaces, $config, $type );
 			}
+
 			return $interfaces;
 
 		}, 10, 3 );
@@ -420,16 +424,16 @@ final class WPGraphQL {
 	/**
 	 * This sets up built-in post_types and taxonomies to show in the GraphQL Schema
 	 *
-	 * @since  0.0.2
 	 * @return void
+	 * @since  0.0.2
 	 */
 	public static function show_in_graphql() {
 		add_filter( 'register_post_type_args', [ __CLASS__, 'setup_default_post_types' ], 10, 2 );
 		add_filter( 'register_taxonomy_args', [ __CLASS__, 'setup_default_taxonomies' ], 10, 2 );
 
 		// Run late so the user can filter the args themselves.
-		add_filter( 'register_post_type_args', [ __CLASS__, 'set_wp_type_args' ], 99, 2 );
-		add_filter( 'register_taxonomy_args', [ __CLASS__, 'set_wp_type_args' ], 99, 2 );
+		add_filter( 'register_post_type_args', [ __CLASS__, 'register_graphql_post_type_args' ], 99, 2 );
+		add_filter( 'register_taxonomy_args', [ __CLASS__, 'register_graphql_taxonomy_args' ], 99, 2 );
 	}
 
 	/**
@@ -462,8 +466,8 @@ final class WPGraphQL {
 	/**
 	 * Sets up the default taxonomies to show_in_graphql.
 	 *
-	 * @param array  $args      Array of arguments for registering a taxonomy.
-	 * @param string $taxonomy  Taxonomy key.
+	 * @param array  $args     Array of arguments for registering a taxonomy.
+	 * @param string $taxonomy Taxonomy key.
 	 *
 	 * @return array
 	 */
@@ -487,21 +491,64 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * This sets the post type /taxonomy GraphQL properties.
+	 * Set the GraphQL Post Type Args and pass them through a filter.
 	 *
-	 * @param array  $args      Array of arguments for registering the type.
-	 * @param string $wp_type   Post type / Taxonomy type key.
+	 * @param array  $args           The graphql specific args for the post type
+	 * @param string $post_type_name The name of the post type being registered
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public static function register_graphql_post_type_args( array $args, string $post_type_name ) {
+
+		$graphql_args = self::get_default_graphql_type_args();
+
+		/**
+		 * Filters the graphql args set on a post type
+		 *
+		 * @param array  $args           The graphql specific args for the post type
+		 * @param string $post_type_name The name of the post type being registered
+		 */
+		$graphql_args = apply_filters( 'register_graphql_post_type_args', $graphql_args, $post_type_name );
+
+		return wp_parse_args( $args, $graphql_args );
+
+	}
+
+	/**
+	 * Set the GraphQL Taxonomy Args and pass them through a filter.
+	 *
+	 * @param array  $args          The graphql specific args for the taxonomy
+	 * @param string $taxonomy_name The name of the taxonomy being registered
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public static function register_graphql_taxonomy_args( array $args, string $taxonomy_name ) {
+
+
+		$graphql_args = self::get_default_graphql_type_args();
+
+		/**
+		 * Filters the graphql args set on a taxonomy
+		 *
+		 * @param array  $args          The graphql specific args for the taxonomy
+		 * @param string $taxonomy_name The name of the taxonomy being registered
+		 */
+		$graphql_args = apply_filters( 'register_graphql_taxonomy_args', $graphql_args, $taxonomy_name );
+
+		return wp_parse_args( $args, $graphql_args );
+
+	}
+
+	/**
+	 * This sets the post type /taxonomy GraphQL properties.
 	 *
 	 * @return array
 	 */
-	public static function set_wp_type_args( $args, $wp_type ) {
+	public static function get_default_graphql_type_args() {
 
-		// Bail early if the post type is hidden from the WPGraphQL schema.
-		if ( empty( $args['show_in_graphql'] ) ) {
-			return $args;
-		}
-
-		$defaults = [
+		return [
 			// The "kind" of GraphQL type to register. Can be `interface`, `object`, or `union`.
 			'graphql_kind'                     => 'object',
 			// The callback used to resolve the type. Only used if `graphql_kind` is an `interface` or `union`.
@@ -520,40 +567,16 @@ final class WPGraphQL {
 			'graphql_register_root_field'      => true,
 			'graphql_register_root_connection' => true,
 		];
-
-		$args = wp_parse_args( $args, $defaults );
-
-		// Ensure a valid type resolver is set for interface and union types.
-		if ( ! is_callable( $args['graphql_resolve_type'] ) && ( 'interface' === $args['graphql_kind'] || 'union' === $args['graphql_kind'] ) ) {
-			throw new Exception(
-				sprintf(
-					__( '%1$s is registered as a GraphQL %2$s, but has no way to resolve the type. Ensure $args[\'graphql_resolve_type\'] is a valid callback function.', 'wp-graphql' ),
-					$wp_type,
-					$args['graphql_kind']
-				)
-			);
-		}
-
-		// Ensure union types have a valid list of possible types.
-		if ( empty( $args['graphql_union_types'] ) && 'union' === $args['graphql_kind'] ) {
-			throw new Exception(
-				sprintf(
-					__( '%1$s is registered as a GraphQL Union, but has list of possible types. Ensure $args[\'graphql_union_types\'] is a valid array of GraphQL type names.', 'wp-graphql' ),
-					$wp_type
-				)
-			);
-		}
-
-		return $args;
 	}
 
 	/**
 	 * Get the post types that are allowed to be used in GraphQL.
-	 * This gets all post_types that are set to show_in_graphql, but allows for external code (plugins/theme) to
-	 * filter the list of allowed_post_types to add/remove additional post_types
+	 * This gets all post_types that are set to show_in_graphql, but allows for external code
+	 * (plugins/theme) to filter the list of allowed_post_types to add/remove additional post_types
 	 *
-	 * @param string|array $output Optional. The type of output to return. Accepts post type 'names' or 'objects'. Default 'names'.
-	 * @param array $args Optional. Arguments to filter allowed post types
+	 * @param string|array $output Optional. The type of output to return. Accepts post type
+	 *                             'names' or 'objects'. Default 'names'.
+	 * @param array        $args   Optional. Arguments to filter allowed post types
 	 *
 	 * @return array
 	 * @since  0.0.4
@@ -604,13 +627,13 @@ final class WPGraphQL {
 			 * Pass through a filter to allow the post_types to be modified.
 			 * For example if a certain post_type should not be exposed to the GraphQL API.
 			 *
-			 * @since 0.0.2
-			 * @since 1.8.1 add $post_type_objects parameter.
-			 *
-			 * @param array $post_type_names Array of post type names.
+			 * @param array $post_type_names   Array of post type names.
 			 * @param array $post_type_objects Array of post type objects.
 			 *
 			 * @return array
+			 * @since 1.8.1 add $post_type_objects parameter.
+			 *
+			 * @since 0.0.2
 			 */
 			$allowed_post_type_names = apply_filters( 'graphql_post_entities_allowed_post_types', $post_type_names, $post_type_objects );
 
@@ -646,14 +669,16 @@ final class WPGraphQL {
 
 	/**
 	 * Get the taxonomies that are allowed to be used in GraphQL.
-	 * This gets all taxonomies that are set to "show_in_graphql" but allows for external code (plugins/themes) to
-	 * filter the list of allowed_taxonomies to add/remove additional taxonomies
+	 * This gets all taxonomies that are set to "show_in_graphql" but allows for external code
+	 * (plugins/themes) to filter the list of allowed_taxonomies to add/remove additional
+	 * taxonomies
 	 *
-	 * @param string $output Optional. The type of output to return. Accepts taxonomy 'names' or 'objects'. Default 'names'.
-	 * @param array $args Optional. Arguments to filter allowed taxonomies.
+	 * @param string $output Optional. The type of output to return. Accepts taxonomy 'names' or
+	 *                       'objects'. Default 'names'.
+	 * @param array  $args   Optional. Arguments to filter allowed taxonomies.
 	 *
-	 * @since  0.0.4
 	 * @return array
+	 * @since  0.0.4
 	 */
 	public static function get_allowed_taxonomies( $output = 'names', $args = [] ) {
 
@@ -693,13 +718,13 @@ final class WPGraphQL {
 			 * Pass through a filter to allow the taxonomies to be modified.
 			 * For example if a certain taxonomy should not be exposed to the GraphQL API.
 			 *
-			 * @since 0.0.2
-			 * @since 1.8.1 add $tax_names and $tax_objects parameters.
-			 *
-			 * @param array $tax_names Array of taxonomy names
+			 * @param array $tax_names   Array of taxonomy names
 			 * @param array $tax_objects Array of taxonomy objects.
 			 *
 			 * @return array
+			 * @since 1.8.1 add $tax_names and $tax_objects parameters.
+			 *
+			 * @since 0.0.2
 			 */
 			$allowed_tax_names = apply_filters( 'graphql_term_entities_allowed_taxonomies', $tax_names, $tax_objects );
 
@@ -762,11 +787,11 @@ final class WPGraphQL {
 			/**
 			 * Generate & Filter the schema.
 			 *
-			 * @since 0.0.5
-			 *
-			 * @param WPSchema   $schema      The executable Schema that GraphQL executes against
-			 * @param AppContext $app_context Object The AppContext object containing all of the
+			 * @param WPSchema   $schema                 The executable Schema that GraphQL executes against
+			 * @param AppContext $app_context            Object The AppContext object containing all of the
 			 *                                           information about the context we know at this point
+			 *
+			 * @since 0.0.5
 			 */
 			self::$schema = apply_filters( 'graphql_schema', $schema, self::get_app_context() );
 		}
@@ -818,11 +843,11 @@ final class WPGraphQL {
 			/**
 			 * Generate & Filter the schema.
 			 *
-			 * @since 0.0.5
-			 *
-			 * @param TypeRegistry $type_registry The TypeRegistry for the API
-			 * @param AppContext   $app_context   Object The AppContext object containing all of the
+			 * @param TypeRegistry $type_registry          The TypeRegistry for the API
+			 * @param AppContext   $app_context            Object The AppContext object containing all of the
 			 *                                             information about the context we know at this point
+			 *
+			 * @since 0.0.5
 			 */
 			self::$type_registry = apply_filters( 'graphql_type_registry', $type_registry, self::get_app_context() );
 		}


### PR DESCRIPTION
- This adds more graceful failing for registering a Post Type or Taxonomy as `graphql_kind => 'union'` but not specifying `graphql_union_types`. 

- This adds new filters `register_graphql_post_type_args` and `register_graphql_taxonomy_args`

I'm missing graphql_debug errors to replace this: https://github.com/justlevine/wp-graphql/pull/1/files#diff-97af7899a9f0c35ff76726275fccd7875b08d2dc490621ab1c30b91809e7f914L527-L535

And I realize I've only added this debug code to PostObject.php, not TermObject.php

The failing tests are related to expecting an Exception, but I've changed it to a `graphql_debug()` message. 