### PR TITLE
chore: update messaging around compatibility and recommended actions before updating

### DIFF
--- a/src/Admin/Updates/PluginsScreenLoader.php
+++ b/src/Admin/Updates/PluginsScreenLoader.php
@@ -2,7 +2,7 @@
 /**
  * Handles plugin update checks and notifications on the plugins screen.
  *
- * Code is inspired by and adapted from WooCommerce's WC_Plugins_Screen_Updates class.
+ * Code is inspired by and adapted from WooCommerce's WC_Plugin_Screen_Updates class.
  *
  * @see https://github.com/woocommerce/woocommerce/blob/5f04212f8188e0f7b09f6375d1a6c610fac8a631/plugins/woocommerce/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
  * *

--- a/src/Admin/Updates/PluginsScreenLoader.php
+++ b/src/Admin/Updates/PluginsScreenLoader.php
@@ -105,8 +105,6 @@ class PluginsScreenLoader {
 		) . '</li>';
 		$message .= '</ol>';
 
-		$post_table_message = __( 'For more information, review each plugin\'s changelogs or contact the plugin\'s developers.', 'wp-graphql' );
-
 		ob_start();
 		?>
 		<div class="wp-graphql-update-notice">
@@ -131,7 +129,8 @@ class PluginsScreenLoader {
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-            <p><?php echo wp_kses_post( $post_table_message ); ?></p>
+			<p><?php echo wp_kses_post( __( 'For more information, review each plugin\'s changelogs or contact the plugin\'s developers.', 'wp-graphql' ) ); ?></p>
+			<p><strong><?php esc_html_e( 'We strongly recommend creating a backup of your site before updating.', 'wp-graphql' ); ?></strong></p>
 		</div>
 
 		<?php

--- a/src/Admin/Updates/PluginsScreenLoader.php
+++ b/src/Admin/Updates/PluginsScreenLoader.php
@@ -80,57 +80,11 @@ class PluginsScreenLoader {
 			return '';
 		}
 
-		$message = sprintf(
-			// translators: %s: The WPGraphQL version wrapped in a strong tag.
-			__(
-				'The following active plugin(s) require WPGraphQL to function but have not yet declared compatibility with %s
-			. Before updating WPGraphQL, please:',
-				'wp-graphql'
-			),
-			// translators: %s: The WPGraphQL version.
-			sprintf( '<strong>WPGraphQL v%s</strong>', $this->update_checker->new_version )
-		);
-
-		$message .= '<ol>';
-		$message .= '<li>' . sprintf(
-			// translators: %s: The WPGraphQL version wrapped in a strong tag.
-			__( 'Update these plugins to their latest versions that declare compatibility with %s, OR', 'wp-graphql' ),
-			// translators: %s: The WPGraphQL version.
-				sprintf( '<strong>WPGraphQL v%s</strong>', $this->update_checker->new_version )
-		) . '</li>';
-		$message .= '<li>' . sprintf(
-			// translators: %s: The WPGraphQL version wrapped in a strong tag.
-			__( 'Confirm their compatibility with %s on your staging environment.', 'wp-graphql' ), // translators: %s: The WPGraphQL version.
-			sprintf( '<strong>WPGraphQL v%s</strong>', $this->update_checker->new_version )
-		) . '</li>';
-		$message .= '</ol>';
-
 		ob_start();
 		?>
 		<div class="wp-graphql-update-notice">
 			<p class="warning"><strong><?php echo esc_html__( 'Untested Plugins:', 'wp-graphql' ); ?></strong></p>
-			<p><?php echo wp_kses_post( $message ); ?></p>
-
-			<table>
-				<thead>
-					<tr>
-						<th><?php esc_html_e( 'Plugin', 'wp-graphql' ); ?></th>
-						<th><?php esc_html_e( 'Plugin\'s Current Version', 'wp-graphql' ); ?></th>
-						<th><?php esc_html_e( 'WPGraphQL Version Tested Up To', 'wp-graphql' ); ?></th>
-					</tr>
-				</thead>
-				<tbody>
-					<?php foreach ( $untested_plugins as $plugin ) : ?>
-						<tr>
-							<td><?php echo esc_html( $plugin['Name'] ); ?></td>
-							<td><?php echo esc_html( $plugin['Version'] ); ?></td>
-							<td><?php echo esc_html( $plugin[ UpdateChecker::TESTED_UP_TO_HEADER ] ); ?></td>
-						</tr>
-					<?php endforeach; ?>
-				</tbody>
-			</table>
-			<p><?php echo wp_kses_post( __( 'For more information, review each plugin\'s changelogs or contact the plugin\'s developers.', 'wp-graphql' ) ); ?></p>
-			<p><strong><?php esc_html_e( 'We strongly recommend creating a backup of your site before updating.', 'wp-graphql' ); ?></strong></p>
+			<?php echo wp_kses_post( $this->update_checker->get_compatibility_warning_message( $untested_plugins ) ); ?>
 		</div>
 
 		<?php

--- a/src/Admin/Updates/PluginsScreenLoader.php
+++ b/src/Admin/Updates/PluginsScreenLoader.php
@@ -2,7 +2,7 @@
 /**
  * Handles plugin update checks and notifications on the plugins screen.
  *
- * Code is inspired by and adapted from WooCommerce's WC_Plugin_Screen_Updates class.
+ * Code is inspired by and adapted from WooCommerce's WC_Plugins_Screen_Updates class.
  *
  * @see https://github.com/woocommerce/woocommerce/blob/5f04212f8188e0f7b09f6375d1a6c610fac8a631/plugins/woocommerce/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
  * *
@@ -82,10 +82,30 @@ class PluginsScreenLoader {
 
 		$message = sprintf(
 			// translators: %s: The WPGraphQL version wrapped in a strong tag.
-			__( 'The following active plugin(s) have not been tested with %s. Please update them or confirm compatibility before updating WPGraphQL, or you may experience issues:', 'wp-graphql' ),
+			__(
+				'The following active plugin(s) require WPGraphQL to function but have not yet declared compatibility with %s
+			. Before updating WPGraphQL, please:',
+				'wp-graphql'
+			),
 			// translators: %s: The WPGraphQL version.
 			sprintf( '<strong>WPGraphQL v%s</strong>', $this->update_checker->new_version )
 		);
+
+		$message .= '<ol>';
+		$message .= '<li>' . sprintf(
+			// translators: %s: The WPGraphQL version wrapped in a strong tag.
+			__( 'Update these plugins to their latest versions that declare compatibility with %s, OR', 'wp-graphql' ),
+			// translators: %s: The WPGraphQL version.
+				sprintf( '<strong>WPGraphQL v%s</strong>', $this->update_checker->new_version )
+		) . '</li>';
+		$message .= '<li>' . sprintf(
+			// translators: %s: The WPGraphQL version wrapped in a strong tag.
+			__( 'Confirm their compatibility with %s on your staging environment.', 'wp-graphql' ), // translators: %s: The WPGraphQL version.
+			sprintf( '<strong>WPGraphQL v%s</strong>', $this->update_checker->new_version )
+		) . '</li>';
+		$message .= '</ol>';
+
+		$post_table_message = __( 'For more information, review each plugin\'s changelogs or contact the plugin\'s developers.', 'wp-graphql' );
 
 		ob_start();
 		?>
@@ -97,8 +117,8 @@ class PluginsScreenLoader {
 				<thead>
 					<tr>
 						<th><?php esc_html_e( 'Plugin', 'wp-graphql' ); ?></th>
-						<th><?php esc_html_e( 'Current Version', 'wp-graphql' ); ?></th>
-						<th><?php esc_html_e( 'WPGraphQL Tested Up To', 'wp-graphql' ); ?></th>
+						<th><?php esc_html_e( 'Plugin\'s Current Version', 'wp-graphql' ); ?></th>
+						<th><?php esc_html_e( 'WPGraphQL Version Tested Up To', 'wp-graphql' ); ?></th>
 					</tr>
 				</thead>
 				<tbody>
@@ -111,6 +131,7 @@ class PluginsScreenLoader {
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+            <p><?php echo wp_kses_post( $post_table_message ); ?></p>
 		</div>
 
 		<?php

--- a/src/Admin/Updates/UpdateChecker.php
+++ b/src/Admin/Updates/UpdateChecker.php
@@ -228,11 +228,30 @@ class UpdateChecker {
 		ob_start();
 
 		$message = sprintf(
-			// translators: %s: The WPGraphQL version wrapped in a strong tag.
-			__( 'The following active plugin(s) have not yet declared compatibility with %s and should be updated and examined further before proceeding:', 'wp-graphql' ),
+		// translators: %s: The WPGraphQL version wrapped in a strong tag.
+			__(
+				'The following active plugin(s) require WPGraphQL to function but have not yet declared compatibility with %s
+			. Before updating WPGraphQL, please:',
+				'wp-graphql'
+			),
 			// translators: %s: The WPGraphQL version.
 			sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
 		);
+
+		$message .= '<ol>';
+		$message .= '<li>' . sprintf(
+			// translators: %s: The WPGraphQL version wrapped in a strong tag.
+			__( 'Update these plugins to their latest versions that declare compatibility with %s, OR', 'wp-graphql' ),
+			// translators: %s: The WPGraphQL version.
+				sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
+		) . '</li>';
+		$message .= '<li>' . sprintf(
+			// translators: %s: The WPGraphQL version wrapped in a strong tag.
+			__( 'Confirm their compatibility with %s on your staging environment.', 'wp-graphql' ), // translators: %s: The WPGraphQL version.
+			sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
+		) . '</li>';
+		$message .= '</ol>';
+
 		?>
 
 		<div id="wp-graphql-update-modal">
@@ -261,6 +280,8 @@ class UpdateChecker {
 							</tbody>
 						</table>
 					</div>
+
+					<p><?php esc_html_e( 'For more information, review each plugin\'s changelogs or contact the plugin\'s developers.', 'wp-graphql' ); ?></p>
 
 					<p><strong><?php esc_html_e( 'We strongly recommend creating a backup of your site before updating.', 'wp-graphql' ); ?></strong></p>
 

--- a/src/Admin/Updates/UpdateChecker.php
+++ b/src/Admin/Updates/UpdateChecker.php
@@ -226,32 +226,6 @@ class UpdateChecker {
 		}
 
 		ob_start();
-
-		$message = sprintf(
-		// translators: %s: The WPGraphQL version wrapped in a strong tag.
-			__(
-				'The following active plugin(s) require WPGraphQL to function but have not yet declared compatibility with %s
-			. Before updating WPGraphQL, please:',
-				'wp-graphql'
-			),
-			// translators: %s: The WPGraphQL version.
-			sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
-		);
-
-		$message .= '<ol>';
-		$message .= '<li>' . sprintf(
-			// translators: %s: The WPGraphQL version wrapped in a strong tag.
-			__( 'Update these plugins to their latest versions that declare compatibility with %s, OR', 'wp-graphql' ),
-			// translators: %s: The WPGraphQL version.
-				sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
-		) . '</li>';
-		$message .= '<li>' . sprintf(
-			// translators: %s: The WPGraphQL version wrapped in a strong tag.
-			__( 'Confirm their compatibility with %s on your staging environment.', 'wp-graphql' ), // translators: %s: The WPGraphQL version.
-			sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
-		) . '</li>';
-		$message .= '</ol>';
-
 		?>
 
 		<div id="wp-graphql-update-modal">
@@ -260,30 +234,7 @@ class UpdateChecker {
 				<h1><?php esc_html_e( 'Are you sure you\'re ready to update?', 'wp-graphql' ); ?></h1>
 
 				<div class="wp-graphql-update-notice">
-					<p><?php echo wp_kses_post( $message ); ?></p>
-
-					<div class="plugin-details-table-container">
-						<table class="plugin-details-table" cellspacing="0">
-							<thead>
-								<tr>
-									<th><?php esc_html_e( 'Plugin', 'wp-graphql' ); ?></th>
-									<th><?php esc_html_e( 'WPGraphQL Tested Up To', 'wp-graphql' ); ?></th>
-								</tr>
-							</thead>
-							<tbody>
-								<?php foreach ( $untested_plugins as $plugin ) : ?>
-									<tr>
-										<td><?php echo esc_html( $plugin['Name'] ); ?></td>
-										<td><?php echo esc_html( $plugin[ self::TESTED_UP_TO_HEADER ] ); ?></td>
-									</tr>
-								<?php endforeach; ?>
-							</tbody>
-						</table>
-					</div>
-
-					<p><?php esc_html_e( 'For more information, review each plugin\'s changelogs or contact the plugin\'s developers.', 'wp-graphql' ); ?></p>
-
-					<p><strong><?php esc_html_e( 'We strongly recommend creating a backup of your site before updating.', 'wp-graphql' ); ?></strong></p>
+					<?php echo wp_kses_post( $this->get_compatibility_warning_message( $untested_plugins ) ); ?>
 
 					<?php if ( current_user_can( 'update_plugins' ) ) : ?>
 						<div class="actions">
@@ -597,5 +548,81 @@ class UpdateChecker {
 		);
 
 		return in_array( 'wp-graphql', $required_plugins, true );
+	}
+
+	/**
+	 * Gets the complete compatibility warning message including the plugins table and follow-up text.
+	 *
+	 * @param array<string,array<string,mixed>> $untested_plugins The untested plugins.
+	 * @return string The formatted HTML message.
+	 */
+	public function get_compatibility_warning_message( array $untested_plugins ): string {
+		ob_start();
+		?>
+		<p>
+		<?php
+		echo wp_kses_post(
+			sprintf(
+			// translators: %s: The WPGraphQL version wrapped in a strong tag.
+				__(
+					'The following active plugin(s) require WPGraphQL to function but have not yet declared compatibility with %s. Before updating WPGraphQL, please:',
+					'wp-graphql'
+				),
+				// translators: %s: The WPGraphQL version.
+				sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
+			)
+		);
+		?>
+		</p>
+
+		<ol>
+			<li>
+			<?php
+			echo wp_kses_post(
+				sprintf(
+				// translators: %s: The WPGraphQL version wrapped in a strong tag.
+					__( 'Update these plugins to their latest versions that declare compatibility with %s, OR', 'wp-graphql' ),
+					sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
+				)
+			);
+			?>
+			</li>
+			<li>
+			<?php
+			echo wp_kses_post(
+				sprintf(
+				// translators: %s: The WPGraphQL version wrapped in a strong tag.
+					__( 'Confirm their compatibility with %s on your staging environment.', 'wp-graphql' ),
+					sprintf( '<strong>WPGraphQL v%s</strong>', $this->new_version )
+				)
+			);
+			?>
+			</li>
+		</ol>
+
+		<div class="plugin-details-table-container">
+			<table class="plugin-details-table" cellspacing="0">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Plugin', 'wp-graphql' ); ?></th>
+						<th><?php esc_html_e( 'WPGraphQL Tested Up To', 'wp-graphql' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $untested_plugins as $plugin ) : ?>
+						<tr>
+							<td><?php echo esc_html( $plugin['Name'] ); ?></td>
+							<td><?php echo esc_html( $plugin[ self::TESTED_UP_TO_HEADER ] ); ?></td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
+
+		<p><?php esc_html_e( 'For more information, review each plugin\'s changelogs or contact the plugin\'s developers.', 'wp-graphql' ); ?></p>
+
+		<p><strong><?php esc_html_e( 'We strongly recommend creating a backup of your site before updating.', 'wp-graphql' ); ?></strong></p>
+		<?php
+		return (string) ob_get_clean();
 	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates the messaging re: plugin compatibility and recommended actions users should take prior to updating. 

Also abstracts the messaging into a single `get_compatibility_warning_message()` method for better reusability and reduced duplicate efforts when/if we need to make adjustments to the messaging. 

Any other comments?
-------------------

## Update Screen

### BEFORE:

![CleanShot 2025-01-07 at 11 14 46](https://github.com/user-attachments/assets/e542944b-3e53-46d7-b40f-53d354f368ce)


### AFTER: 

![CleanShot 2025-01-07 at 11 12 42](https://github.com/user-attachments/assets/bd86495f-4151-4179-a536-3ea7231f9aef)

## Plugin Screen

### BEFORE:

![CleanShot 2025-01-07 at 11 14 12](https://github.com/user-attachments/assets/eb3045a0-3ff1-43b5-913d-0dcde5edfdde)


### AFTER: 

![CleanShot 2025-01-07 at 11 13 01](https://github.com/user-attachments/assets/a9e575bd-912f-49be-9aeb-d81a59a248a2)
